### PR TITLE
Fix inability to create on demand instances.

### DIFF
--- a/src/main/scala/EmrSparkPlugin.scala
+++ b/src/main/scala/EmrSparkPlugin.scala
@@ -234,7 +234,7 @@ object EmrSparkPlugin extends AutoPlugin {
             .get
             .withInstanceGroups {
               val masterConfig = Some(new InstanceGroupConfig())
-                .map(c => settings.instanceBidPrice.fold(c)(c.withMarket(MarketType.SPOT).withBidPrice))
+                .map(c => settings.instanceBidPrice.fold(c.withMarket(MarketType.ON_DEMAND))(c.withMarket(MarketType.SPOT).withBidPrice))
                 .get
                 .withInstanceCount(1)
                 .withInstanceRole(InstanceRoleType.MASTER)
@@ -242,7 +242,7 @@ object EmrSparkPlugin extends AutoPlugin {
 
               val slaveCount = settings.instanceCount - 1
               val slaveConfig = Some(new InstanceGroupConfig())
-                .map(c => settings.instanceBidPrice.fold(c)(c.withMarket(MarketType.SPOT).withBidPrice))
+                .map(c => settings.instanceBidPrice.fold(c.withMarket(MarketType.ON_DEMAND))(c.withMarket(MarketType.SPOT).withBidPrice))
                 .get
                 .withInstanceCount(slaveCount)
                 .withInstanceRole(InstanceRoleType.CORE)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version := "0.6.0"
+version := "0.6.1-SNAPSHOT"


### PR DESCRIPTION
Fixes: https://github.com/pishen/sbt-emr-spark/issues/5

Looks like when the bid price was None we weren't setting the MarketType to OnDemand. It was failing when creating the cluster because it looks like the default is actually Spot pricing and it was failing because we hadn't set a bid.

This is tested on my side and seems to resolve the issue.

Thanks for the neat plugin! This is really handy for me! :smile: 