### PR TITLE
Use the name of the class as step name.

### DIFF
--- a/src/main/scala/sbtlighter/LighterPlugin.scala
+++ b/src/main/scala/sbtlighter/LighterPlugin.scala
@@ -450,7 +450,7 @@ object LighterPlugin extends AutoPlugin {
 
     val step = new StepConfig()
       .withActionOnFailure(ActionOnFailure.CONTINUE)
-      .withName("Spark Step")
+      .withName(mainClass.split(".").lastOption.getOrElse("Spark Step"))
       .withHadoopJarStep(
         new HadoopJarStepConfig()
           .withJar("command-runner.jar")


### PR DESCRIPTION
When re-using the same cluster for submitting different jobs it can be
confusing using the default "Spark Step"-name. It would be clearer when
using the name of the class that is being used in the
sparkSubmit-statement