### PR TITLE
Add BootstrapActions setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ sparkS3LogUri := Some("s3://my-emr-bucket/my-emr-log-folder/")
 
 //Configs of --conf when running spark-submit, default is an empty Map.
 sparkSubmitConfs := Map("spark.executor.memory" -> "10G", "spark.executor.instances" -> "2")
+
+//List of EMR bootstrap scripts and their parameters, if any, default is Seq.empty.
+sparkEmrBootstrap := Seq(BootstrapAction("my-bootstrap", "s3://my-production-bucket/bootstrap.sh", "--full"))
 ```
 
 ## Other available commands
@@ -275,7 +278,6 @@ inConfig(Production)(LighterPlugin.baseSettings ++ Seq(
   sparkS3LogUri := Some("s3://aws-logs-************-us-west-2/elasticmapreduce/")
   sparkCorePrice := Some(0.39),
   sparkEmrConfigs := Seq(EmrConfig("spark", Map("maximizeResourceAllocation" -> "true")))
-  sparkEmrBootstrap := Seq(BootstrapAction("my-bootstrap", "s3://my-production-bucket/bootstrap.sh", "--full"))
 ))
 ```
 

--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ inConfig(Production)(LighterPlugin.baseSettings ++ Seq(
   sparkS3LogUri := Some("s3://aws-logs-************-us-west-2/elasticmapreduce/")
   sparkCorePrice := Some(0.39),
   sparkEmrConfigs := Seq(EmrConfig("spark", Map("maximizeResourceAllocation" -> "true")))
+  sparkEmrBootstrap := Seq(BootstrapAction("my-bootstrap", "s3://my-production-bucket/bootstrap.sh", "--full"))
 ))
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,6 @@
 name := "sbt-lighter"
 
-version := "1.1.0"
+version := "1.2.0"
 
 scalaVersion := "2.12.4"
 

--- a/src/main/scala/sbtlighter/BootstrapAction.scala
+++ b/src/main/scala/sbtlighter/BootstrapAction.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017 Pishen Tsai
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sbtlighter
+
+import com.amazonaws.services.elasticmapreduce.model.{
+  BootstrapActionConfig,
+  ScriptBootstrapActionConfig
+}
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
+import scala.collection.JavaConverters._
+
+case class BootstrapAction(
+  name: String,
+  path: String,
+  args: String*
+) {
+  def toAwsBootstrapActionConfig(): BootstrapActionConfig = {
+    new BootstrapActionConfig()
+      .withName(name)
+      .withScriptBootstrapAction(
+        new ScriptBootstrapActionConfig()
+          .withPath(path)
+          .withArgs(args.asJava))
+  }
+}

--- a/src/main/scala/sbtlighter/LighterPlugin.scala
+++ b/src/main/scala/sbtlighter/LighterPlugin.scala
@@ -47,6 +47,8 @@ object LighterPlugin extends AutoPlugin {
       settingKey[String]("EMR Service Role")
     val sparkEmrConfigs =
       settingKey[Seq[EmrConfig]]("EMR Configurations")
+    val sparkEmrBootstrap =
+      settingKey[Seq[BootstrapAction]]("EMR Cluster Bootstrap Scripts")
     val sparkEmrApplications =
       settingKey[Seq[String]]("EMR Applications")
     val sparkVisibleToAllUsers =
@@ -142,6 +144,7 @@ object LighterPlugin extends AutoPlugin {
     sparkEmrRelease := "emr-5.14.0",
     sparkEmrServiceRole := "EMR_DefaultRole",
     sparkEmrConfigs := Seq.empty,
+    sparkEmrBootstrap := Seq.empty,
     sparkEmrApplications := Seq("Spark"),
     sparkVisibleToAllUsers := true,
     sparkSubnetId := None,
@@ -258,6 +261,12 @@ object LighterPlugin extends AutoPlugin {
           val emrConfigs = sparkEmrConfigs.value
           if (emrConfigs.nonEmpty) {
             r.withConfigurations(emrConfigs.map(_.toAwsEmrConfig()): _*)
+          } else r
+        }
+        .map { r =>
+          val actions = sparkEmrBootstrap.value
+          if (actions.nonEmpty) {
+            r.withBootstrapActions(actions.map(_.toAwsBootstrapActionConfig()).asJava)
           } else r
         }
         .map { r =>


### PR DESCRIPTION
This change exposes the EMR Bootstrap Actions configuration, allows to specify them explicitly.
I tested this through `publishLocal` and it appears to work with or without the `args` specified.

While writing this I realized that this is already possible by hooking into `sparkRunJobFlowRequest` but thats not at all obvious unless you're pretty familiar with the AWS SDK and not pretty either.

If this looks good I would like to add `BootstrapAction!.fromFile(file)` method that would trigger an upload of bootstrap script during `sparkSubmit` and `sparkSubmitMain` tasks in subsequent PR.